### PR TITLE
Fix tag handling, remove user personal data from tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ coverage.xml
 
 # Sphinx documentation
 docs/_build/
+
+# User data
+skippy/property/profile.json
+skippy/property/session.json

--- a/skippy/property/profile.json
+++ b/skippy/property/profile.json
@@ -1,1 +1,0 @@
-{"login": "", "password": ""}

--- a/skippy/utils/profile.py
+++ b/skippy/utils/profile.py
@@ -7,14 +7,12 @@ import os
 class Profile:
     @staticmethod
     def load():
-        try:
-            with open(
-                os.path.join(skippy.config.PROPERTY_FOLDER, "profile.json"), "r"
-            ) as f:
+        profile_path = os.path.join(skippy.config.PROPERTY_FOLDER, "profile.json")
+        if os.path.exists(profile_path):
+            with open(profile_path, "r") as f:
                 profile = json.loads(f.read())
-
-            return (profile["login"], profile["password"])
-        except json.decoder.JSONDecodeError:
+                return (profile["login"], profile["password"])
+        else:
             return ("", "")
 
     @staticmethod

--- a/skippy/utils/session.py
+++ b/skippy/utils/session.py
@@ -40,8 +40,11 @@ class Session:
         log.debug(f"Save session to {path}")
 
     def load(self, path=os.path.join(skippy.config.PROPERTY_FOLDER, "session.json")):
-        with open(path, "r") as f:
-            session = f.read()
+        if os.path.exists(path):
+            with open(path, "r") as f:
+                session = f.read()
+        else:
+            session = ""
         if session != "":
             session = json.loads(session)
             self.set_session(session)

--- a/skippy/widget.py
+++ b/skippy/widget.py
@@ -426,7 +426,7 @@ class ProjectList(QWidget):
         tags_box = FileUploadLineEdit()
         if isinstance(tags, collections.Iterable):
             tags_box.setText(" ".join(tags))
-        tags_box.textChanged.connect(lambda text: setData("tags", text))
+        tags_box.textChanged.connect(lambda text: setData("tags", text.split(' ')))
         tags_box.setStyleSheet("QLineEdit{font-family: Arial; font-size:11pt;}")
 
         files_button = QPushButton("Files", self)


### PR DESCRIPTION
There was mixed typing in widget.data["tags"] (sometimes string, sometimes list). This confused pyscp a lot and resulted in broken tags being uploaded.